### PR TITLE
Use delete instead of remove

### DIFF
--- a/lib/connect-hazelcast.js
+++ b/lib/connect-hazelcast.js
@@ -43,7 +43,7 @@ module.exports = (session) => {
 
     HazelcastStore.prototype.destroy = function (sid, cb) {
         this.client.getMap(this.prefix).then(map => {
-            map.remove(sid).then(() => {
+            map.delete(sid).then(() => {
                 cb(null, 'OK');
             }).catch(cb);
         });


### PR DESCRIPTION
Delete is faster than remove because it eliminates deserialization cost of the returned value.